### PR TITLE
Remove area dropdown and show username

### DIFF
--- a/dashboard.php
+++ b/dashboard.php
@@ -12,7 +12,7 @@ require_once "config/db.php";
 <body>
     <?php include "includes/header.php"; ?>
     <main class="container">
-        <h2>Bienvenido, <?= htmlspecialchars($_SESSION['rol']) ?></h2>
+        <h2>Bienvenido, <?= htmlspecialchars($_SESSION['nombre']) ?></h2>
         <p>Selecciona una opción del menú para comenzar.</p>
     </main>
     <?php include "includes/footer.php"; ?>

--- a/includes/header.php
+++ b/includes/header.php
@@ -23,7 +23,8 @@ if (strpos($_SERVER['PHP_SELF'], '/admin/') !== false ||
                     <li><a href="<?= $prefix ?>dashboard.php">Inicio</a></li>
                     <li><a href="<?= $prefix ?>jefe_area/crear_ticket.php">Crear Ticket</a></li>
                     <li><a href="<?= $prefix ?>jefe_area/ver_tickets.php">Mis Tickets</a></li>
-                    <li><a href="<?= $prefix ?>jefe_area/usuarios.php">Usuarios</a></li>
+                    <!-- <li><a href="<?= $prefix ?>jefe_area/usuarios.php">Usuarios</a></li> -->
+                    <li><a href="<?= $prefix ?>coming_soon/usuarios.php">Usuarios</a></li>
                 <?php else: ?>
                     <li><a href="<?= $prefix ?>dashboard.php">Inicio</a></li>
                 <?php endif; ?>

--- a/jefe_area/crear_ticket.php
+++ b/jefe_area/crear_ticket.php
@@ -9,21 +9,21 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     verify_csrf();
     $titulo = trim($_POST['titulo']);
     $descripcion = trim($_POST['descripcion']);
-    $prioridad = $_POST['prioridad'];
-    $area = (int)$_POST['area'];
+    $estado = $_POST['estado'];
     $usuario = $_SESSION['id_usuario'];
-    if (!in_array($prioridad, ['Baja', 'Media', 'Alta'])) {
-        $error = 'Prioridad inválida';
+    $area    = $_SESSION['id_area'];
+    if (!in_array($estado, ['Pendiente', 'En proceso', 'Realizado'])) {
+        $error = 'Estado inválido';
     } else {
+        $prioridad = 'Media';
         $stmt = $conn->prepare(
-            "INSERT INTO Ticket (titulo, descripcion, prioridad, estado, id_usuario, id_area) VALUES (?, ?, ?, 'Pendiente', ?, ?)"
+            "INSERT INTO Ticket (titulo, descripcion, prioridad, estado, id_usuario, id_area) VALUES (?, ?, ?, ?, ?, ?)"
         );
         $stmt->execute([
-            $titulo, $descripcion, $prioridad, $usuario, $area
+            $titulo, $descripcion, $prioridad, $estado, $usuario, $area
         ]);
     }
 }
-$areas = $conn->query("SELECT * FROM Area")->fetchAll();
 ?>
 <!DOCTYPE html>
 <html>
@@ -41,15 +41,10 @@ $areas = $conn->query("SELECT * FROM Area")->fetchAll();
             <input type="hidden" name="csrf_token" value="<?= csrf_token() ?>">
             <input type="text" name="titulo" placeholder="Título" required>
             <textarea name="descripcion" placeholder="Descripción" required></textarea>
-            <select name="prioridad">
-                <option value="Baja">Baja</option>
-                <option value="Media">Media</option>
-                <option value="Alta">Alta</option>
-            </select>
-            <select name="area">
-                <?php foreach ($areas as $a): if ($a['nombre_area'] === 'Usuarios') continue; ?>
-                <option value="<?= $a['id_area'] ?>"><?= htmlspecialchars($a['nombre_area']) ?></option>
-                <?php endforeach; ?>
+            <select name="estado">
+                <option value="Pendiente">Pendiente</option>
+                <option value="En proceso">En proceso</option>
+                <option value="Realizado">Realizado</option>
             </select>
             <button type="submit">Crear</button>
         </form>

--- a/jefe_area/ver_tickets.php
+++ b/jefe_area/ver_tickets.php
@@ -24,12 +24,11 @@ $tickets = $stmt->fetchAll();
     <main class="container">
         <h2>Mis Tickets</h2>
         <table>
-            <tr><th>Título</th><th>Descripción</th><th>Prioridad</th><th>Estado</th><th>Área</th><th>Fecha</th></tr>
+            <tr><th>Título</th><th>Descripción</th><th>Estado</th><th>Área</th><th>Fecha</th></tr>
             <?php foreach ($tickets as $row): ?>
             <tr>
                 <td><?= htmlspecialchars($row['titulo']) ?></td>
                 <td><?= htmlspecialchars($row['descripcion']) ?></td>
-                <td><?= $row['prioridad'] ?></td>
                 <td><?= $row['estado'] ?></td>
                 <td><?= $row['nombre_area'] ?></td>
                 <td><?= $row['fecha_creacion'] ?></td>

--- a/login.php
+++ b/login.php
@@ -17,6 +17,7 @@ try {
         if ($row) {
             if (password_verify($password, $row['password'])) {
                 $_SESSION['id_usuario'] = $row['id_usuario'];
+                $_SESSION['nombre'] = $row['nombre'];
                 $_SESSION['rol'] = $row['rol'];
                 $_SESSION['id_area'] = $row['id_area'];
                 header("Location: dashboard.php");
@@ -28,6 +29,7 @@ try {
                 $upd = $conn->prepare("UPDATE Usuario SET password = ? WHERE id_usuario = ?");
                 $upd->execute([$newHash, $row['id_usuario']]);
                 $_SESSION['id_usuario'] = $row['id_usuario'];
+                $_SESSION['nombre'] = $row['nombre'];
                 $_SESSION['rol'] = $row['rol'];
                 $_SESSION['id_area'] = $row['id_area'];
                 header("Location: dashboard.php");


### PR DESCRIPTION
## Summary
- set user area from session when creating tickets
- remove area selection and priority on new tickets
- list tickets without priority column
- display logged-in username on dashboard
- redirect jefe_area user link to coming soon page

## Testing
- `php -l login.php` *(fails: command not found)*
- `php -l dashboard.php` *(fails: command not found)*
- `php -l jefe_area/crear_ticket.php` *(fails: command not found)*
- `php -l jefe_area/ver_tickets.php` *(fails: command not found)*
- `php -l includes/header.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865c51fb26c832591feb43d490b1942